### PR TITLE
Add JS item method for allow indexation from VFP in fastparsermode

### DIFF
--- a/json.PRG
+++ b/json.PRG
@@ -2411,6 +2411,11 @@ if (typeof JSON !== "object") {
 
                 j = eval("(" + text + ")");
 
+// James Suárez 26-11-2022
+// add prototype item function 
+
+				Object.prototype.item = function(index) { return this[index] }
+
 // In the optional fourth stage, we recursively walk the new structure, passing
 // each name/value pair to a reviver function for possible transformation.
 


### PR DESCRIPTION
This allow get non-valid properties from VFP, or access easy to any array from VFP.

Example: 
```harbour
result = JSON.parse("[1, "Prueba", {"a": 1}]")
?m.result.item[0]
?m.result.item[1]
?m.result.item[2]
```