### PR TITLE
Add more relevance to new method item over parsed property item

### DIFF
--- a/json.PRG
+++ b/json.PRG
@@ -2414,7 +2414,36 @@ if (typeof JSON !== "object") {
 // James Suárez 26-11-2022
 // add prototype item function 
 
-				Object.prototype.item = function(index) { return this[index] }
+				function goodParse(obj){
+					if(obj && typeof obj == "object"){
+						if(!(obj instanceof Array)){
+							for(var id in obj){
+								if(id.toUpperCase() == "ITEM"){								
+									// ocultar la variable
+									obj["...." + id] = obj[id]
+									delete obj[id]
+								}
+								else{
+									var value = obj[id]
+									if(typeof value == "object"){
+										goodParse(value)
+									}
+								}
+							}
+						}
+					}
+					return obj 
+				}
+				
+				goodParse(j)
+				Object.prototype.item = function() {
+					var index = arguments[0]
+					if(index === undefined || index === null) index = "....item"					
+					if(typeof index == "string" && index.toUpperCase()=="ITEM"){
+						index= "...." + index
+					}
+					return this[index]
+				}
 
 // In the optional fourth stage, we recursively walk the new structure, passing
 // each name/value pair to a reviver function for possible transformation.

--- a/json.PRG
+++ b/json.PRG
@@ -2417,17 +2417,15 @@ if (typeof JSON !== "object") {
 				function goodParse(obj){
 					if(obj && typeof obj == "object"){
 						if(!(obj instanceof Array)){
+							var value = obj[id]
 							for(var id in obj){
 								if(id.toUpperCase() == "ITEM"){								
 									// ocultar la variable
-									obj["...." + id] = obj[id]
+									obj["...." + id] = value
 									delete obj[id]
 								}
-								else{
-									var value = obj[id]
-									if(typeof value == "object"){
-										goodParse(value)
-									}
+								if(typeof value == "object"){
+									goodParse(value)
 								}
 							}
 						}


### PR DESCRIPTION
El método  ```item``` ahora tendría mayor relevancia que una propiedad item. De ese modo el método siempre está disponible, y no se oculta bajo ningún caso, aún cuando se parsea un objeto que tenga la propiedad item. Si en un código específico se necesita acceder a una propiedad  ```item```, entonces se necesitaría usar el método ```item```:

```harbour
result = JSON.parse('{"item": {"count": 1}, "nums":[1000,2000],"$order": 1}')

* acceder a la propiedad item
?m.result.item["item"]

* mostraría 1
?m.result.item["item"].count 

* acceder a propiedades no válidas en VFP
?m.result.item["$order"]

* los arrays se pueden acceder también con item (mostraría 1000)
?m.result.nums.item[0]
```
Aclaración que este código no afecta ningún otro funcionamiento, y aún se puede acceder a los array usando el comando FOREACH de VFP. 
Con este cambio, se puede decir que la librería serviría tanto para acceder a propiedades comunes, como acceder a propiedades no válidas, y manteniendo un excelente rendimiento ya que no involucra creación de objetos en VFP.

Saludos.


